### PR TITLE
Fixes #150

### DIFF
--- a/src/main/resources/org/got5/tapestry5/jquery/tapestry-jquery.js
+++ b/src/main/resources/org/got5/tapestry5/jquery/tapestry-jquery.js
@@ -845,14 +845,8 @@ $.tapestry = {
             var redirectURL = reply.redirectURL;
             
             if (redirectURL) {
-                // Check for complete URL.
-                if (/^https?:/.test(redirectURL)) {
-                    window.location = redirectURL;
-                    return;
-                }
-                
-                window.location.pathname = redirectURL;
-                
+                window.location = redirectURL;
+
                 // Don't bother loading scripts or invoking the callback.
                 return;
             }


### PR DESCRIPTION
Fixes #150 : Redirect URL not well handled in javascript, it breaks the redirect in other browsers than Firefox when request parameters are present in the redirect URL
