### PR TITLE
don't show debug level messages is Tapestry.DEBUG_ENABLED is false

### DIFF
--- a/src/main/resources/org/got5/tapestry5/jquery/t5-console-jquery.js
+++ b/src/main/resources/org/got5/tapestry5/jquery/t5-console-jquery.js
@@ -75,7 +75,11 @@
 	        /** Time, in seconds, that floating console messages are displayed to the user. */
 	        DURATION  : 10000,
 	
-	        debug : level("t-debug", nativeConsole.debug),
+	        debug : function(message) {
+	            if (Tapestry.DEBUG_ENABLED) {
+	                level("t-debug", nativeConsole.debug).call(window, message);
+	            }
+          },
 	        info : level("t-info", nativeConsole.info),
 	        warn : level("t-warn", nativeConsole.warn),
 	        error : error


### PR DESCRIPTION
Debug messages are shown regardless of what `Tapestry.DEBUG_ENABLED` is set to.
