### PR TITLE
send the t:zoneid parameter in a zone update ajax request

### DIFF
--- a/src/main/resources/org/got5/tapestry5/jquery/tapestry-jquery.js
+++ b/src/main/resources/org/got5/tapestry5/jquery/tapestry-jquery.js
@@ -614,7 +614,7 @@ $.widget( "ui.tapestryZone", {
 		}
 
     $.extend(ajaxRequest, {
-		  data: specs.params ? $.extend(specs.params, {'t:zoneid': this.element.attr("id")}) : {'t:zoneid': this.element..attr("id")} 
+		  data: specs.params ? $.extend(specs.params, {'t:zoneid': this.element.attr("id")}) : {'t:zoneid': this.element.attr("id")}
     });
     $.tapestry.utils.ajaxRequest(ajaxRequest);
   },


### PR DESCRIPTION
see TAP5-1061: When a Zone component sends an Ajax request for a client-side update, it should pass an extra query parameter identifying the zone's client-side id
