### PR TITLE
send the t:zoneid parameter in a zone update ajax request

### DIFF
--- a/src/main/resources/org/got5/tapestry5/jquery/tapestry-jquery.js
+++ b/src/main/resources/org/got5/tapestry5/jquery/tapestry-jquery.js
@@ -577,7 +577,7 @@ $.widget( "ui.tapestryZone", {
      */
     update: function(specs) {
         
-		var that = this;
+		var that = this, zoneIdInfo = {'t:zoneid': this.element.attr("id")};
 		var ajaxRequest = {
 				url: specs.url,
 				type: "POST", 
@@ -613,13 +613,18 @@ $.widget( "ui.tapestryZone", {
 			$.extend(specs.params, this.options.parameters);
 		}
 
-		if (specs.params) {
-			$.extend(ajaxRequest, {
-				data: specs.params
-			});
-		}
-		$.tapestry.utils.ajaxRequest(ajaxRequest);
-	}, 
+    if(specs.params && typeof specs.params === 'string'){
+       $.extend(ajaxRequest, {
+                 data: specs.params + '&' + $.param(zoneIdInfo)
+      });
+    } else {
+      $.extend(ajaxRequest, {
+                 data: specs.params ? $.extend(specs.params, zoneIdInfo) : zoneIdInfo
+      });
+    }
+
+    $.tapestry.utils.ajaxRequest(ajaxRequest);
+  },
 	
 	/**
 	 * Updates the element's content and triggers the appropriate effect on the


### PR DESCRIPTION
Fixed version of #159:
see TAP5-1061: When a Zone component sends an Ajax request for a client-side update, it should pass an extra query parameter identifying the zone's client-side id
Now it also works if the parameters passed to `update()` are already serialized.
