### PR TITLE
IE js error thrown in Tapestry.error when debug tools open

### DIFF
--- a/src/main/resources/org/got5/tapestry5/jquery/t5-console-jquery.js
+++ b/src/main/resources/org/got5/tapestry5/jquery/t5-console-jquery.js
@@ -65,7 +65,7 @@
 	    		
 	    		// Chrome doesn't automatically output a trace with the error message.
 	            // FireFox does.
-	    		if (! $.browser.safari) {
+	    		if (! $.browser.safari && console.trace) {
 	                console.trace();
 	            }
 	    	}


### PR DESCRIPTION
Go here in IE8+:
http://tapestry5-jquery.com/

In addressbar type:
javascript:Tapestry.error("foo");

It will work fine, showing the alert message.

Now open the IE developer tools and do the same. A js error will be logged.
