### PR TITLE
Fixed adding a context to a droppable zone's url for ZoneDroppable mixin.

### DIFF
--- a/src/main/resources/org/got5/tapestry5/jquery/assets/mixins/zonedroppable/zonedroppable.js
+++ b/src/main/resources/org/got5/tapestry5/jquery/assets/mixins/zonedroppable/zonedroppable.js
@@ -6,7 +6,11 @@
     		$( "#" + specs.id ).bind( "drop", function(event, ui) {
     			 var contexte=$(ui.draggable).data("contexte");
     			 var element = $("#" + specs.id);
-    			 var urlWithContexte =specs.BaseURL + "/" + contexte;
+				 
+				 var parts = specs.BaseURL.split("?");
+				 parts[0] += "/" + encodeURIComponent(contexte);
+				 var urlWithContexte = parts.join("?");
+
     			 element.tapestryZone("update" , {url : urlWithContexte});
     		});
         }


### PR DESCRIPTION
Fixed adding a context to a droppable zone's url in case it is used inside a component with an activation context.
