### PR TITLE
JS loaded per ajax is not debuggable in Firebug or any other Browser Debugger

### DIFF
--- a/src/main/resources/org/got5/tapestry5/jquery/tapestry-jquery.js
+++ b/src/main/resources/org/got5/tapestry5/jquery/tapestry-jquery.js
@@ -816,33 +816,47 @@ $.tapestry = {
          * @param callback invoked after scripts are loaded
          */
         addScripts: function(scripts, callback) {
-            if (scripts) {
-            
-                $.each(scripts, function(i, s) {
-                    var assetURL = $.tapestry.utils.rebuildURL(s);
-                    var virtualScripts = $('html').data(Tapestry.VIRTUAL_SCRIPTS);
-                    
-                    if (!virtualScripts) {
-                        virtualScripts = [];
-                        
-                        $('script[src]').each(function(i, script) {
-                            path = $(script).attr('src');
-                            virtualScripts.push($.tapestry.utils.rebuildURL(path));
-                        });
-                    }
-                    
-                    if ($.inArray(assetURL, virtualScripts) === -1) {
-                        $('head').append('<script src="' + assetURL + '" type="text/javascript" />');
-                        virtualScripts.push(assetURL);
-                    }
-                    
-                    $('html').data(Tapestry.VIRTUAL_SCRIPTS, virtualScripts);
-                });
+            if (!scripts) {
+                // TODO : re-implement scriptLoadMonitor
+                callback.call(this);
+                return;
+            }
+
+            var virtualScripts = $('html').data(Tapestry.VIRTUAL_SCRIPTS);
+            if (!virtualScripts) {
+                virtualScripts = [];
                 
+                $('script[src]').each(function(i, script) {
+                    path = $(script).attr('src');
+                    virtualScripts.push($.tapestry.utils.rebuildURL(path));
+                });
             }
             
-            // TODO : re-implement scriptLoadMonitor
-            callback.call(this);
+            var callbacks = [];
+            $.each(scripts, function(i, scriptURL){
+            	callbacks.push(function(){
+            		 var assetURL = $.tapestry.utils.rebuildURL(scriptURL);
+                     if ($.inArray(assetURL, virtualScripts) === -1) {
+                         var script   = document.createElement("script");
+                         script.type  = "text/javascript";
+                         script.src   = assetURL;
+                         document.getElementsByTagName('head')[0].appendChild(script);
+                         virtualScripts.push(assetURL);
+                         if(i == callbacks.length - 2)
+                        	 $('html').data(Tapestry.VIRTUAL_SCRIPTS, virtualScripts);
+                         var completed = false;
+                         script.onload = script.onreadystatechange = function () {
+                        	 if (!completed && (!this.readyState || this.readyState == 'loaded' || this.readyState == 'complete')) {
+                        		 completed = true;
+                        		 script.onload = script.onreadystatechange = null;
+                        		 callbacks[i + 1].call(this);
+                        	 }
+                         };
+                     }
+            	});
+            });
+            callbacks.push(callback);
+            callbacks[0].call(this);
         },
         
         addStylesheets: function(stylesheets) {


### PR DESCRIPTION
JS loaded per ajax is not debuggable in Firebug or any other Browser Debugger
- Refactoring the addScript function to not use jQuery.addScript (which
  doesn't add a script element in head instead just executes the
  script) and instead use plain javascript. The reason is keeping
  consistency with the behaviour with tapestry-core and tapestry5-jquery
  when SUPPRESS_PROTOTYPE=false. The behaiour was noticed while
  integrating the tynamo.org tapestry-ckeditor module with
  tapestry5-jquery. CKEditor's initialization javascript looks for
  ckeditor.js in the head part in order to set CKEDITOR.basePath to the
  base path of the ckeditor folder.
