### PR TITLE
jQuery's loading of stylesheets has troubles with relative urls and @imports

### DIFF
--- a/src/main/resources/org/got5/tapestry5/jquery/tapestry-jquery.js
+++ b/src/main/resources/org/got5/tapestry5/jquery/tapestry-jquery.js
@@ -1027,15 +1027,15 @@
 
 						if ($.inArray(assetURL, loaded) === -1) {
 
-							stylesheet = '<link href="' + assetURL
-									+ '" type="text/css" rel="stylesheet"';
+							var style = document.createElement("link");
+							style.setAttribute("type", "text/css");
+							style.setAttribute("rel", "stylesheet");
+							style.setAttribute("href", assetURL);
+							if (s.media) {
+								style.setAttribute("media", s.media);
+							}
 
-							if (s.media)
-								stylesheet += ' media="' + s.media + '" ';
-
-							stylesheet += '/>';
-
-							$('head').append(stylesheet);
+							$('head')[0].appendChild(style);
 						}
 					});
 				}


### PR DESCRIPTION
As described in http://bugs.jquery.com/ticket/12145, jQuery's way of loading stylesheets has troubles in Internet Explorer 8 on Windows XP.

While Tapestry does use absolute urls to fetch the assets, the issue with `@import` stylesheets is still present when handling an AJAX response.
