### PR TITLE
`addScripts` stops processing callbacks once any script in the array is found to be already included on the page

### DIFF
--- a/src/main/resources/org/got5/tapestry5/jquery/tapestry-jquery.js
+++ b/src/main/resources/org/got5/tapestry5/jquery/tapestry-jquery.js
@@ -967,7 +967,9 @@
 	                        	 }
 	                         };
 	                     });
-	            	}
+	                } else {
+	                    callbacks[i + 1].call(this);
+	                }
 	            });
 	            callbacks.push(callback);
 	            callbacks[0].call(this);


### PR DESCRIPTION
This means that the final callback is never run and as a consequence `executeInits` is never given the chance to do it's thing.
