### PR TITLE
Changed: In autocomplete, save the ajax object to `this.xhr`

### DIFF
--- a/src/main/resources/org/got5/tapestry5/jquery/assets/mixins/autocomplete/autocomplete.js
+++ b/src/main/resources/org/got5/tapestry5/jquery/assets/mixins/autocomplete/autocomplete.js
@@ -24,7 +24,7 @@
 	                        dataType: "json", 
 	                        type:"POST"
 	                    };
-	                    $.ajax(ajaxRequest);
+	                    this.xhr = $.ajax(ajaxRequest);
 	                }
 	        };
 	        if (specs.delay >= 0) 


### PR DESCRIPTION
By default, jQuery saves the `xhr` object returned from $.ajax into `this.xhr` from within the `source` function. This is used by the `autocomplete("disable")` method to cancel pending ajax requests.
