### PR TITLE
JavaScriptFilesConfigurationImpl.getAsset should match assets by full filename

### DIFF
--- a/src/main/java/org/got5/tapestry5/jquery/services/impl/JavaScriptFilesConfigurationImpl.java
+++ b/src/main/java/org/got5/tapestry5/jquery/services/impl/JavaScriptFilesConfigurationImpl.java
@@ -20,10 +20,9 @@ public class JavaScriptFilesConfigurationImpl implements
 	}
 
 	public Asset getAsset(Asset original) {
-		for(String key : javaScriptFilesConfiguration.keySet()){
-			if(original.getResource().getFile().endsWith(key)){
-				return InternalUtils.isBlank(javaScriptFilesConfiguration.get(key)) ? null : this.as.getExpandedAsset(javaScriptFilesConfiguration.get(key));
-			}
+		if(javaScriptFilesConfiguration.containsKey(original.getResource().getFile())) {
+			String assetPath = javaScriptFilesConfiguration.get(original.getResource().getFile());
+			return InternalUtils.isBlank(assetPath) ? null : this.as.getExpandedAsset(assetPath);
 		}
 		return original;
 	}


### PR DESCRIPTION
JavaScriptFilesConfigurationImpl.getAsset: Match assets by filename
using map key lookup instead of iterating the map's keyset and matching
the assets using endsWith. 
- There was a bug introduced in 0779e6c
  where by matching assets using endsWith resulted in t5-prototype.js and
  prototype.js to be matched non uniquely.
- The code is more optimized since we're doing now a map lookup instead
  of iterating the map's keyset.
