### PR TITLE
Fix of IE9 error related to palette and use of optgroup elements in select

### DIFF
--- a/src/main/resources/org/got5/tapestry5/jquery/assets/components/palette/palette.js
+++ b/src/main/resources/org/got5/tapestry5/jquery/assets/components/palette/palette.js
@@ -196,7 +196,7 @@ $.widget( "ui.palette", {
 			    } catch (e){
 				    //select.remove(..) throws exception in ie9, when select contains optgroup
 				    //see http://social.msdn.microsoft.com/Forums/is/iewebdevelopment/thread/2ab12546-7bb4-41b6-8d36-442cc0ecb153
-				    from.removeChild(from.childNodes[i]);
+				    $(from).find("option[value='"+option.value+"']").remove();
 				}
 				i--;
                 movers.push(option);


### PR DESCRIPTION
....microsoft.com/Forums/is/iewebdevelopment/thread/2ab12546-7bb4-41b6-8d36-442cc0ecb153

when invoking select.remove(..) in IE9 and the select contains optgroup
element, select.remove(..) will throw exception. Solution - catch
exception and remove element using ordinary dom manipulation
