### PR TITLE
Update jquery.jgrowl.js to 1.2.12; fixes beforeClose param is not working

### DIFF
--- a/src/main/resources/org/got5/tapestry5/jquery/assets/components/jgrowl/jquery.jgrowl.js
+++ b/src/main/resources/org/got5/tapestry5/jquery/assets/components/jgrowl/jquery.jgrowl.js
@@ -1,29 +1,50 @@
 /**
- * jGrowl 1.2.6
+ * jGrowl 1.2.12
  *
  * Dual licensed under the MIT (http://www.opensource.org/licenses/mit-license.php)
  * and GPL (http://www.opensource.org/licenses/gpl-license.php) licenses.
  *
  * Written by Stan Lemon <stosh1985@gmail.com>
- * Last updated: 2011.03.27
+ * Last updated: 2013.02.14
  *
- * jGrowl is a jQuery plugin implementing unobtrusive userland notifications.  These 
+ * jGrowl is a jQuery plugin implementing unobtrusive userland notifications.  These
  * notifications function similarly to the Growl Framework available for
  * Mac OS X (http://growl.info).
  *
  * To Do:
  * - Move library settings to containers and allow them to be changed per container
  *
+ * Changes in 1.2.13
+ * - Fixed clearing interval when the container shuts down
+ *
+ * Changes in 1.2.12
+ * - Added compressed versions using UglifyJS and Sqwish
+ * - Improved README with configuration options explanation
+ * - Added a source map
+ *
+ * Changes in 1.2.11
+ * - Fix artifacts left behind by the shutdown method and text-cleanup
+ *
+ * Changes in 1.2.10
+ * - Fix beforeClose to be called in click event
+ *
+ * Changes in 1.2.9
+ * - Fixed BC break in jQuery 2.0 beta
+ *
+ * Changes in 1.2.8
+ * - Fixes for jQuery 1.9 and the MSIE6 check, note that with jQuery 2.0 support
+ *   jGrowl intends to drop support for IE6 altogether
+ *
  * Changes in 1.2.6
  * - Fixed js error when a notification is opening and closing at the same time
- * 
+ *
  * Changes in 1.2.5
  * - Changed wrapper jGrowl's options usage to "o" instead of $.jGrowl.defaults
  * - Added themeState option to control 'highlight' or 'error' for jQuery UI
  * - Ammended some CSS to provide default positioning for nested usage.
  * - Changed some CSS to be prefixed with jGrowl- to prevent namespacing issues
- * - Added two new options - openDuration and closeDuration to allow 
- *   better control of notification open and close speeds, respectively 
+ * - Added two new options - openDuration and closeDuration to allow
+ *   better control of notification open and close speeds, respectively
  *   Patch contributed by Jesse Vincet.
  * - Added afterOpen callback.  Patch contributed by Russel Branca.
  *
@@ -106,233 +127,238 @@
  * - Namespaced all events
  */
 (function($) {
+        /** Compatibility holdover for 1.9 to check IE6 **/
+	var $ie6 = (function(){
+		return false === $.support.boxModel && $.support.objectAll && $.support.leadingWhitespace;
+	})();
 
-        /** jGrowl Wrapper - Establish a base jGrowl Container for compatibility with older releases. **/
-        $.jGrowl = function( m , o ) {
-                // To maintain compatibility with older version that only supported one instance we'll create the base container.
-                if ( $('#jGrowl').size() == 0 ) 
-                        $('<div id="jGrowl"></div>').addClass( (o && o.position) ? o.position : $.jGrowl.defaults.position ).appendTo('body');
+	/** jGrowl Wrapper - Establish a base jGrowl Container for compatibility with older releases. **/
+	$.jGrowl = function( m , o ) {
+		// To maintain compatibility with older version that only supported one instance we'll create the base container.
+		if ( $('#jGrowl').size() == 0 )
+			$('<div id="jGrowl"></div>').addClass( (o && o.position) ? o.position : $.jGrowl.defaults.position ).appendTo('body');
 
-                // Create a notification on the container.
-                $('#jGrowl').jGrowl(m,o);
-        };
-
-
-        /** Raise jGrowl Notification on a jGrowl Container **/
-        $.fn.jGrowl = function( m , o ) {
-                if ( $.isFunction(this.each) ) {
-                        var args = arguments;
-
-                        return this.each(function() {
-                                var self = this;
-
-                                /** Create a jGrowl Instance on the Container if it does not exist **/
-                                if ( $(this).data('jGrowl.instance') == undefined ) {
-                                        $(this).data('jGrowl.instance', $.extend( new $.fn.jGrowl(), { notifications: [], element: null, interval: null } ));
-                                        $(this).data('jGrowl.instance').startup( this );
-                                }
-
-                                /** Optionally call jGrowl instance methods, or just raise a normal notification **/
-                                if ( $.isFunction($(this).data('jGrowl.instance')[m]) ) {
-                                        $(this).data('jGrowl.instance')[m].apply( $(this).data('jGrowl.instance') , $.makeArray(args).slice(1) );
-                                } else {
-                                        $(this).data('jGrowl.instance').create( m , o );
-                                }
-                        });
-                };
-        };
-
-        $.extend( $.fn.jGrowl.prototype , {
-
-                /** Default JGrowl Settings **/
-                defaults: {
-                        pool:                   0,
-                        header:                 '',
-                        group:                  '',
-                        sticky:                 false,
-                        position:               'top-right',
-                        glue:                   'after',
-                        theme:                  'default',
-                        themeState:     'highlight',
-                        corners:                '10px',
-                        check:                  250,
-                        life:                   3000,
-                        closeDuration:  'normal',
-                        openDuration:   'normal',
-                        easing:                 'swing',
-                        closer:                 true,
-                        closeTemplate: '&times;',
-                        closerTemplate: '<div>[ close all ]</div>',
-                        log:                    function(e,m,o) {},
-                        beforeOpen:     function(e,m,o) {},
-                        afterOpen:              function(e,m,o) {},
-                        open:                   function(e,m,o) {},
-                        beforeClose:    function(e,m,o) {},
-                        close:                  function(e,m,o) {},
-                        animateOpen:    {
-                                opacity:        'show'
-                        },
-                        animateClose:   {
-                                opacity:        'hide'
-                        }
-                },
-                
-                notifications: [],
-                
-                /** jGrowl Container Node **/
-                element:        null,
-        
-                /** Interval Function **/
-                interval:   null,
-                
-                /** Create a Notification **/
-                create:         function( message , o ) {
-                        var o = $.extend({}, this.defaults, o);
-
-                        /* To keep backward compatibility with 1.24 and earlier, honor 'speed' if the user has set it */
-                        if (typeof o.speed !== 'undefined') {
-                                o.openDuration = o.speed;
-                                o.closeDuration = o.speed;
-                        }
-
-                        this.notifications.push({ message: message , options: o });
-                        
-                        o.log.apply( this.element , [this.element,message,o] );
-                },
-                
-                render:                 function( notification ) {
-                        var self = this;
-                        var message = notification.message;
-                        var o = notification.options;
-
-                        // Support for jQuery theme-states, if this is not used it displays a widget header
-                        o.themeState = (o.themeState == '') ? '' : 'ui-state-' + o.themeState;
-
-                        var notification = $(
-                                '<div class="jGrowl-notification ' + o.themeState + ' ui-corner-all' + 
-                                ((o.group != undefined && o.group != '') ? ' ' + o.group : '') + '">' +
-                                '<div class="jGrowl-close">' + o.closeTemplate + '</div>' +
-                                '<div class="jGrowl-header">' + o.header + '</div>' +
-                                '<div class="jGrowl-message">' + message + '</div></div>'
-                        ).data("jGrowl", o).addClass(o.theme).children('div.jGrowl-close').bind("click.jGrowl", function() {
-                                $(this).parent().trigger('jGrowl.close');
-                        }).parent();
+		// Create a notification on the container.
+		$('#jGrowl').jGrowl(m,o);
+	};
 
 
-                        /** Notification Actions **/
-                        $(notification).bind("mouseover.jGrowl", function() {
-                                $('div.jGrowl-notification', self.element).data("jGrowl.pause", true);
-                        }).bind("mouseout.jGrowl", function() {
-                                $('div.jGrowl-notification', self.element).data("jGrowl.pause", false);
-                        }).bind('jGrowl.beforeOpen', function() {
-                                if ( o.beforeOpen.apply( notification , [notification,message,o,self.element] ) != false ) {
-                                        $(this).trigger('jGrowl.open');
-                                }
-                        }).bind('jGrowl.open', function() {
-                                if ( o.open.apply( notification , [notification,message,o,self.element] ) != false ) {
-                                        if ( o.glue == 'after' ) {
-                                                $('div.jGrowl-notification:last', self.element).after(notification);
-                                        } else {
-                                                $('div.jGrowl-notification:first', self.element).before(notification);
-                                        }
-                                        
-                                        $(this).animate(o.animateOpen, o.openDuration, o.easing, function() {
-                                                // Fixes some anti-aliasing issues with IE filters.
-                                                if ($.browser.msie && (parseInt($(this).css('opacity'), 10) === 1 || parseInt($(this).css('opacity'), 10) === 0))
-                                                        this.style.removeAttribute('filter');
+	/** Raise jGrowl Notification on a jGrowl Container **/
+	$.fn.jGrowl = function( m , o ) {
+		if ( $.isFunction(this.each) ) {
+			var args = arguments;
 
-                                                if ( $(this).data("jGrowl") != null ) // Happens when a notification is closing before it's open.
-                                                        $(this).data("jGrowl").created = new Date();
-                                                
-                                                $(this).trigger('jGrowl.afterOpen');
-                                        });
-                                }
-                        }).bind('jGrowl.afterOpen', function() {
-                                o.afterOpen.apply( notification , [notification,message,o,self.element] );
-                        }).bind('jGrowl.beforeClose', function() {
-                                if ( o.beforeClose.apply( notification , [notification,message,o,self.element] ) != false )
-                                        $(this).trigger('jGrowl.close');
-                        }).bind('jGrowl.close', function() {
-                                // Pause the notification, lest during the course of animation another close event gets called.
-                                $(this).data('jGrowl.pause', true);
-                                $(this).animate(o.animateClose, o.closeDuration, o.easing, function() {
-                                        if ( $.isFunction(o.close) ) {
-                                                if ( o.close.apply( notification , [notification,message,o,self.element] ) !== false )
-                                                        $(this).remove();
-                                        } else {
-                                                $(this).remove();
-                                        }
-                                });
-                        }).trigger('jGrowl.beforeOpen');
-                
-                        /** Optional Corners Plugin **/
-                        if ( o.corners != '' && $.fn.corner != undefined ) $(notification).corner( o.corners );
+			return this.each(function() {
+				/** Create a jGrowl Instance on the Container if it does not exist **/
+				if ( $(this).data('jGrowl.instance') == undefined ) {
+					$(this).data('jGrowl.instance', $.extend( new $.fn.jGrowl(), { notifications: [], element: null, interval: null } ));
+					$(this).data('jGrowl.instance').startup( this );
+				}
 
-                        /** Add a Global Closer if more than one notification exists **/
-                        if ( $('div.jGrowl-notification:parent', self.element).size() > 1 && 
-                                 $('div.jGrowl-closer', self.element).size() == 0 && this.defaults.closer != false ) {
-                                $(this.defaults.closerTemplate).addClass('jGrowl-closer ' + this.defaults.themeState + ' ui-corner-all').addClass(this.defaults.theme)
-                                        .appendTo(self.element).animate(this.defaults.animateOpen, this.defaults.speed, this.defaults.easing)
-                                        .bind("click.jGrowl", function() {
-                                                $(this).siblings().trigger("jGrowl.beforeClose");
+				/** Optionally call jGrowl instance methods, or just raise a normal notification **/
+				if ( $.isFunction($(this).data('jGrowl.instance')[m]) ) {
+					$(this).data('jGrowl.instance')[m].apply( $(this).data('jGrowl.instance') , $.makeArray(args).slice(1) );
+				} else {
+					$(this).data('jGrowl.instance').create( m , o );
+				}
+			});
+		};
+	};
 
-                                                if ( $.isFunction( self.defaults.closer ) ) {
-                                                        self.defaults.closer.apply( $(this).parent()[0] , [$(this).parent()[0]] );
-                                                }
-                                        });
-                        };
-                },
+	$.extend( $.fn.jGrowl.prototype , {
 
-                /** Update the jGrowl Container, removing old jGrowl notifications **/
-                update:  function() {
-                        $(this.element).find('div.jGrowl-notification:parent').each( function() {
-                                if ( $(this).data("jGrowl") != undefined && $(this).data("jGrowl").created != undefined && 
-                                         ($(this).data("jGrowl").created.getTime() + parseInt($(this).data("jGrowl").life))  < (new Date()).getTime() && 
-                                         $(this).data("jGrowl").sticky != true && 
-                                         ($(this).data("jGrowl.pause") == undefined || $(this).data("jGrowl.pause") != true) ) {
+		/** Default JGrowl Settings **/
+		defaults: {
+			pool:				0,
+			header:				'',
+			group:				'',
+			sticky:				false,
+			position: 			'top-right',
+			glue:				'after',
+			theme:				'default',
+			themeState:			'highlight',
+			corners:			'10px',
+			check:				250,
+			life:				3000,
+			closeDuration: 		'normal',
+			openDuration: 		'normal',
+			easing: 			'swing',
+			closer: 			true,
+			closeTemplate: 		'&times;',
+			closerTemplate: 	'<div>[ close all ]</div>',
+			log:				function() {},
+			beforeOpen:			function() {},
+			afterOpen:			function() {},
+			open:				function() {},
+			beforeClose: 		function() {},
+			close:				function() {},
+			animateOpen: 		{
+				opacity:	 'show'
+			},
+			animateClose: 		{
+				opacity:	 'hide'
+			}
+		},
 
-                                        // Pause the notification, lest during the course of animation another close event gets called.
-                                        $(this).trigger('jGrowl.beforeClose');
-                                }
-                        });
+		notifications: [],
 
-                        if ( this.notifications.length > 0 && 
-                                 (this.defaults.pool == 0 || $(this.element).find('div.jGrowl-notification:parent').size() < this.defaults.pool) )
-                                this.render( this.notifications.shift() );
+		/** jGrowl Container Node **/
+		element:	 null,
 
-                        if ( $(this.element).find('div.jGrowl-notification:parent').size() < 2 ) {
-                                $(this.element).find('div.jGrowl-closer').animate(this.defaults.animateClose, this.defaults.speed, this.defaults.easing, function() {
-                                        $(this).remove();
-                                });
-                        }
-                },
+		/** Interval Function **/
+		interval:   null,
 
-                /** Setup the jGrowl Notification Container **/
-                startup:        function(e) {
-                        this.element = $(e).addClass('jGrowl').append('<div class="jGrowl-notification"></div>');
-                        this.interval = setInterval( function() { 
-                                $(e).data('jGrowl.instance').update(); 
-                        }, parseInt(this.defaults.check));
-                        
-                        if ($.browser.msie && parseInt($.browser.version) < 7 && !window["XMLHttpRequest"]) {
-                                $(this.element).addClass('ie6');
-                        }
-                },
+		/** Create a Notification **/
+		create:	 function( message , o ) {
+			var o = $.extend({}, this.defaults, o);
 
-                /** Shutdown jGrowl, removing it and clearing the interval **/
-                shutdown:   function() {
-                        $(this.element).removeClass('jGrowl').find('div.jGrowl-notification').remove();
-                        clearInterval( this.interval );
-                },
-                
-                close:  function() {
-                        $(this.element).find('div.jGrowl-notification').each(function(){
-                                $(this).trigger('jGrowl.beforeClose');
-                        });
-                }
-        });
-        
-        /** Reference the Defaults Object for compatibility with older versions of jGrowl **/
-        $.jGrowl.defaults = $.fn.jGrowl.prototype.defaults;
+			/* To keep backward compatibility with 1.24 and earlier, honor 'speed' if the user has set it */
+			if (typeof o.speed !== 'undefined') {
+				o.openDuration = o.speed;
+				o.closeDuration = o.speed;
+			}
+
+			this.notifications.push({ message: message , options: o });
+
+			o.log.apply( this.element , [this.element,message,o] );
+		},
+
+		render:		 function( notification ) {
+			var self = this;
+			var message = notification.message;
+			var o = notification.options;
+
+			// Support for jQuery theme-states, if this is not used it displays a widget header
+			o.themeState = (o.themeState == '') ? '' : 'ui-state-' + o.themeState;
+
+			var notification = $('<div/>')
+				.addClass('jGrowl-notification ' + o.themeState + ' ui-corner-all' + ((o.group != undefined && o.group != '') ? ' ' + o.group : ''))
+				.append($('<div/>').addClass('jGrowl-close').html(o.closeTemplate))
+				.append($('<div/>').addClass('jGrowl-header').html(o.header))
+				.append($('<div/>').addClass('jGrowl-message').html(message))
+				.data("jGrowl", o).addClass(o.theme).children('div.jGrowl-close').bind("click.jGrowl", function() {
+					$(this).parent().trigger('jGrowl.beforeClose');
+				})
+				.parent();
+
+
+			/** Notification Actions **/
+			$(notification).bind("mouseover.jGrowl", function() {
+				$('div.jGrowl-notification', self.element).data("jGrowl.pause", true);
+			}).bind("mouseout.jGrowl", function() {
+				$('div.jGrowl-notification', self.element).data("jGrowl.pause", false);
+			}).bind('jGrowl.beforeOpen', function() {
+				if ( o.beforeOpen.apply( notification , [notification,message,o,self.element] ) !== false ) {
+					$(this).trigger('jGrowl.open');
+				}
+			}).bind('jGrowl.open', function() {
+				if ( o.open.apply( notification , [notification,message,o,self.element] ) !== false ) {
+					if ( o.glue == 'after' ) {
+						$('div.jGrowl-notification:last', self.element).after(notification);
+					} else {
+						$('div.jGrowl-notification:first', self.element).before(notification);
+					}
+
+					$(this).animate(o.animateOpen, o.openDuration, o.easing, function() {
+						// Fixes some anti-aliasing issues with IE filters.
+						if ($.support.opacity === false)
+							this.style.removeAttribute('filter');
+
+						if ( $(this).data("jGrowl") !== null ) // Happens when a notification is closing before it's open.
+							$(this).data("jGrowl").created = new Date();
+
+						$(this).trigger('jGrowl.afterOpen');
+					});
+				}
+			}).bind('jGrowl.afterOpen', function() {
+				o.afterOpen.apply( notification , [notification,message,o,self.element] );
+			}).bind('jGrowl.beforeClose', function() {
+				if ( o.beforeClose.apply( notification , [notification,message,o,self.element] ) !== false )
+					$(this).trigger('jGrowl.close');
+			}).bind('jGrowl.close', function() {
+				// Pause the notification, lest during the course of animation another close event gets called.
+				$(this).data('jGrowl.pause', true);
+				$(this).animate(o.animateClose, o.closeDuration, o.easing, function() {
+					if ( $.isFunction(o.close) ) {
+						if ( o.close.apply( notification , [notification,message,o,self.element] ) !== false )
+							$(this).remove();
+					} else {
+						$(this).remove();
+					}
+				});
+			}).trigger('jGrowl.beforeOpen');
+
+			/** Optional Corners Plugin **/
+			if ( o.corners != '' && $.fn.corner != undefined ) $(notification).corner( o.corners );
+
+			/** Add a Global Closer if more than one notification exists **/
+			if ( $('div.jGrowl-notification:parent', self.element).size() > 1 &&
+				 $('div.jGrowl-closer', self.element).size() == 0 && this.defaults.closer !== false ) {
+				$(this.defaults.closerTemplate).addClass('jGrowl-closer ' + this.defaults.themeState + ' ui-corner-all').addClass(this.defaults.theme)
+					.appendTo(self.element).animate(this.defaults.animateOpen, this.defaults.speed, this.defaults.easing)
+					.bind("click.jGrowl", function() {
+						$(this).siblings().trigger("jGrowl.beforeClose");
+
+						if ( $.isFunction( self.defaults.closer ) ) {
+							self.defaults.closer.apply( $(this).parent()[0] , [$(this).parent()[0]] );
+						}
+					});
+			};
+		},
+
+		/** Update the jGrowl Container, removing old jGrowl notifications **/
+		update:	 function() {
+			$(this.element).find('div.jGrowl-notification:parent').each( function() {
+				if ( $(this).data("jGrowl") != undefined && $(this).data("jGrowl").created !== undefined &&
+					 ($(this).data("jGrowl").created.getTime() + parseInt($(this).data("jGrowl").life))  < (new Date()).getTime() &&
+					 $(this).data("jGrowl").sticky !== true &&
+					 ($(this).data("jGrowl.pause") == undefined || $(this).data("jGrowl.pause") !== true) ) {
+
+					// Pause the notification, lest during the course of animation another close event gets called.
+					$(this).trigger('jGrowl.beforeClose');
+				}
+			});
+
+			if ( this.notifications.length > 0 &&
+				 (this.defaults.pool == 0 || $(this.element).find('div.jGrowl-notification:parent').size() < this.defaults.pool) )
+				this.render( this.notifications.shift() );
+
+			if ( $(this.element).find('div.jGrowl-notification:parent').size() < 2 ) {
+				$(this.element).find('div.jGrowl-closer').animate(this.defaults.animateClose, this.defaults.speed, this.defaults.easing, function() {
+					$(this).remove();
+				});
+			}
+		},
+
+		/** Setup the jGrowl Notification Container **/
+		startup:	function(e) {
+			this.element = $(e).addClass('jGrowl').append('<div class="jGrowl-notification"></div>');
+			this.interval = setInterval( function() {
+				$(e).data('jGrowl.instance').update();
+			}, parseInt(this.defaults.check));
+
+			if ($ie6) {
+				$(this.element).addClass('ie6');
+			}
+		},
+
+		/** Shutdown jGrowl, removing it and clearing the interval **/
+		shutdown:   function() {
+			$(this.element).removeClass('jGrowl')
+				.find('div.jGrowl-notification').trigger('jGrowl.close')
+				.parent().empty()
+
+			clearInterval(this.interval);
+		},
+
+		close:	 function() {
+			$(this.element).find('div.jGrowl-notification').each(function(){
+				$(this).trigger('jGrowl.beforeClose');
+			});
+		}
+	});
+
+	/** Reference the Defaults Object for compatibility with older versions of jGrowl **/
+	$.jGrowl.defaults = $.fn.jGrowl.prototype.defaults;
 
 })(jQuery);


### PR DESCRIPTION
...g

reported on the t5 mailinglist:
http://apache-tapestry-mailing-list-archives.1045711.n5.nabble.com/jquery-jgrowl-params-not-working-td5722275.html

reported in t5-jquery google group:
https://groups.google.com/forum/?hl=de#!topic/tapestry5-jquery/mNg_H4JkhpY
