### PR TITLE
Missing initializer caused "TypeError: initf is undefined"

### DIFF
--- a/src/main/resources/org/got5/tapestry5/jquery/tapestry-jquery.js
+++ b/src/main/resources/org/got5/tapestry5/jquery/tapestry-jquery.js
@@ -26,6 +26,7 @@
 									$().log(
 											"No Tapestry.Initializer function for : "
 													+ functionName);
+									return;
 								}
 
 								$.each(params, function(i, paramList) {


### PR DESCRIPTION
if an initializer does not exist, don't try to execute it.
