### PR TITLE
#352 simple fix

### DIFF
--- a/src/main/java/org/got5/tapestry5/jquery/mixins/Confirm.java
+++ b/src/main/java/org/got5/tapestry5/jquery/mixins/Confirm.java
@@ -54,10 +54,10 @@ public class Confirm
 	private int height;
 
 	/**
-	 * Confirmation box height.
+	 * Confirmation box width.
 	 */
 	@Parameter(value = "250", defaultPrefix = BindingConstants.LITERAL)
-	private int widht;
+	private int width;
 	
 	/**
 	 * If this parameter is set to <i>true</i>, the user can't interact with the application while the

--- a/src/main/java/org/got5/tapestry5/jquery/mixins/Confirm.java
+++ b/src/main/java/org/got5/tapestry5/jquery/mixins/Confirm.java
@@ -54,6 +54,12 @@ public class Confirm
 	private int height;
 
 	/**
+	 * Confirmation box height.
+	 */
+	@Parameter(value = "250", defaultPrefix = BindingConstants.LITERAL)
+	private int widht;
+	
+	/**
 	 * If this parameter is set to <i>true</i>, the user can't interact with the application while the
 	 * confirmation box is displayed.
 	 */
@@ -120,6 +126,7 @@ public class Confirm
     	config.put("isResizable", isResizable);
     	config.put("isDraggable", isDraggable);
     	config.put("height", height);
+    	config.put("width", width);
 
     	javaScriptSupport.addInitializerCall(InitializationPriority.EARLY,"confirm", config);
     }

--- a/src/main/resources/org/got5/tapestry5/jquery/assets/mixins/confirm/confirm.js
+++ b/src/main/resources/org/got5/tapestry5/jquery/assets/mixins/confirm/confirm.js
@@ -9,6 +9,7 @@
                     autoOpen : false,
                     resizable : specs.isResizable,
                     height : specs.height,
+                    width : specs.width,
                     resize : 'auto',
                     title : specs.title,
                     modal : specs.isModal,


### PR DESCRIPTION
#352 changes to Confirm mixin to allow a "width" parameter when not using the default js confirm, at the moment still a int parameter, therefore not allowing "auto" (like issued in #353)