### PR TITLE
Issue correction Tabs.java

### DIFF
--- a/src/main/java/org/got5/tapestry5/jquery/components/Tabs.java
+++ b/src/main/java/org/got5/tapestry5/jquery/components/Tabs.java
@@ -128,7 +128,7 @@ public class Tabs extends AbstractExtendableComponent
 
         JSONObject defaults = new JSONObject();
         defaults.put("cache", false);
-        defaults.put("selected", activePanelId);
+        defaults.put("active", activePanelId);
 
         JQueryUtils.merge(defaults, params);
 


### PR DESCRIPTION
The JSON parameter used in JS for the selected tab is not "selected", it is "active".