### PR TITLE
PageScroll.js keeps replacing the content of the previous page load

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Exclusive jQuery components :
 - **InPlaceEditor** 
 	- based on [http://www.appelsiini.net/projects/jeditable](http://www.appelsiini.net/projects/jeditable)
 - **PageScroller** 
-	- Infinite Scrolling Pagination. [Example on how to use it](/src/test/resources/org/got5/tapestry5/jquery/pages/PageScroll.tml) 
+	- Infinite Scrolling Pagination. Example on how to use it: [TML](/src/test/resources/org/got5/tapestry5/jquery/pages/PageScroll.tml) & [Java](/src/test/java/org/got5/tapestry5/jquery/pages/PageScroll.java) 
 - **RangeSlider** 
 	- based on [http://jqueryui.com/demos/slider/#range](http://jqueryui.com/demos/slider/#range)
 - **Slider** 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Exclusive jQuery components :
 - **InPlaceEditor** 
 	- based on [http://www.appelsiini.net/projects/jeditable](http://www.appelsiini.net/projects/jeditable)
 - **PageScroller** 
-	- Infinite Scrolling Pagination. [Example on how to use it](/repo/blob/master/src/test/resources/org/got5/tapestry5/jquery/pages/PageScroll.tml) 
+	- Infinite Scrolling Pagination. [Example on how to use it](/src/test/resources/org/got5/tapestry5/jquery/pages/PageScroll.tml) 
 - **RangeSlider** 
 	- based on [http://jqueryui.com/demos/slider/#range](http://jqueryui.com/demos/slider/#range)
 - **Slider** 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Exclusive jQuery components :
 	- based on [https://github.com/woothemes/FlexSlider](https://github.com/woothemes/FlexSlider)	
 - **InPlaceEditor** 
 	- based on [http://www.appelsiini.net/projects/jeditable](http://www.appelsiini.net/projects/jeditable)
+- **PageScroller** 
+	- Infinite Scrolling Pagination. [Example on how to use it](/repo/blob/master/src/test/resources/org/got5/tapestry5/jquery/pages/PageScroll.tml) 
 - **RangeSlider** 
 	- based on [http://jqueryui.com/demos/slider/#range](http://jqueryui.com/demos/slider/#range)
 - **Slider** 

--- a/src/main/java/org/got5/tapestry5/jquery/components/PageScroll.java
+++ b/src/main/java/org/got5/tapestry5/jquery/components/PageScroll.java
@@ -25,7 +25,6 @@ import org.apache.tapestry5.internal.services.ArrayEventContext;
 import org.apache.tapestry5.internal.util.CaptureResultCallback;
 import org.apache.tapestry5.ioc.services.TypeCoercer;
 import org.apache.tapestry5.json.JSONObject;
-import org.apache.tapestry5.services.Request;
 import org.apache.tapestry5.services.javascript.JavaScriptSupport;
 import org.got5.tapestry5.jquery.JQueryEventConstants;
 
@@ -107,9 +106,6 @@ public class PageScroll implements ClientElement {
     @Inject
     private TypeCoercer typeCoercer;
 
-    @Inject
-    private Request request;
-
     private EventContext eventContext;
 
     @BeginRender
@@ -124,6 +120,7 @@ public class PageScroll implements ClientElement {
             .put("scroller", scroller)
             .put("scrollURI", getScrollURI())
             .put("zoneId", zone)
+            .put("firstPageNumber", pageNumber)
             .put("params", params);
 
         javaScriptSupport.require("tjq/PageScroll").with(specs);

--- a/src/main/resources/META-INF/modules/tjq/PageScroll.js
+++ b/src/main/resources/META-INF/modules/tjq/PageScroll.js
@@ -14,7 +14,7 @@ define([ "t5/core/dom", "t5/core/zone", "t5/core/events", "tjq/vendor/components
                 activeZone;
 
             if (typeof (this.pageIndex) == "undefined") {
-                this.pageIndex = 0;
+                this.pageIndex = specs.firstPageNumber >= 0 ? specs.firstPageNumber : 0;
             }
 
             if (this.pageIndex === -1 || this.disable) {

--- a/src/main/resources/META-INF/modules/tjq/PageScroll.js
+++ b/src/main/resources/META-INF/modules/tjq/PageScroll.js
@@ -21,9 +21,17 @@ define([ "t5/core/dom", "t5/core/zone", "t5/core/events", "tjq/vendor/components
                 return;
             }
 
+            var pageZoneId = specs.zoneId + pageIndex;
             element = dom.wrap(specs.scroller);
-            element.attr("data-update-zone", specs.zoneId);
+            element.attr("data-update-zone", pageZoneId);
             activeZone = zone.findZone(element);
+            
+            var newPageZone = dom.wrap(activeZone.$.clone());
+            var nextPageIndex = pageIndex + 1;
+            var nextPageZoneId = specs.zoneId + nextPageIndex;
+            newPageZone.attr("id", nextPageZoneId);
+            activeZone.insertAfter(newPageZone);
+            element.attr("data-update-zone", nextPageZoneId);
 
             this.disable = true;
             scroller.addClass("scrollExtend-loading");

--- a/src/test/java/org/got5/tapestry5/jquery/PageScrollTest.java
+++ b/src/test/java/org/got5/tapestry5/jquery/PageScrollTest.java
@@ -22,6 +22,18 @@ public class PageScrollTest extends SeleniumTestCase {
 
         assertTrue(isTextPresent("Element#300"));
         assertTrue(isTextPresent("Element#302"));
+
+        assertFalse(isTextPresent("Element#500"));
+        assertFalse(isTextPresent("Element#502"));
+
+        this.runScript("window.scrollTo(0,Math.max(document.documentElement.scrollHeight," +
+                "document.body.scrollHeight,document.documentElement.clientHeight));");
+
+        sleep(1500);
+
+        assertTrue(isTextPresent("Element#500"));
+        assertTrue(isTextPresent("Element#502"));
+
     }
 
 }

--- a/src/test/java/org/got5/tapestry5/jquery/pages/PageScroll.java
+++ b/src/test/java/org/got5/tapestry5/jquery/pages/PageScroll.java
@@ -2,8 +2,10 @@ package org.got5.tapestry5.jquery.pages;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.apache.tapestry5.annotations.OnEvent;
 import org.apache.tapestry5.annotations.Property;
+import org.got5.tapestry5.jquery.JQueryEventConstants;
 
 public class PageScroll {
 
@@ -15,7 +17,7 @@ public class PageScroll {
 
     private static final int PAGE_SIZE = 100;
 
-    @OnEvent("nextPage")
+    @OnEvent(JQueryEventConstants.NEXT_PAGE)
     List<Integer> moreValues(int multiplyBy) throws InterruptedException {
         List<Integer> values = new ArrayList<Integer>();
         for (int i = pageNumber * PAGE_SIZE;

--- a/src/test/java/org/got5/tapestry5/jquery/services/AppModule.java
+++ b/src/test/java/org/got5/tapestry5/jquery/services/AppModule.java
@@ -56,7 +56,7 @@ public class AppModule
     	configuration.add(SymbolConstants.ASSET_PATH_PREFIX, "assets");
     	configuration.add("demo-src-dir", "");
 
-    	//configuration.add(SymbolConstants.JAVASCRIPT_INFRASTRUCTURE_PROVIDER, "jquery");
+        configuration.add(SymbolConstants.JAVASCRIPT_INFRASTRUCTURE_PROVIDER, "jquery");
 
     	configuration.add(SymbolConstants.HMAC_PASSPHRASE, "testing, testing, 1... 2... 3...");
 

--- a/src/test/resources/org/got5/tapestry5/jquery/pages/PageScroll.tml
+++ b/src/test/resources/org/got5/tapestry5/jquery/pages/PageScroll.tml
@@ -27,7 +27,7 @@
             scroller='scroller' zone='zone'>
             <li>Element#${value}</li>
         </li>
-        <li class='zone' t:type='zone' t:id='zone'/>
+        <li class='zone' t:type='zone' t:id='zone0'/>
     </ul>
 
     <div id='scroller'></div>


### PR DESCRIPTION
Hi,

I have just added PageScroll component to my Tapestry App.
The first scroll triggered data retrieval works fine and shows the result properly.
However the second scroll data retrieval is broken. It is not appending the returned HTML elements, but replaces first scroll triggered section.

I managed to fix it in my app, by overriding the PageScroll.js as below, however it is not working in PageScrollTest.java due to not finding $ in activeZone.$.clone().
It work in my pure jQuery app, but it seems that this test page is also loading prototype and for some reason not exposing $ via ElementWrapper.
I am not sure how to overcome this challenge. Could you please advise.
